### PR TITLE
added tests and examples, fixed „main“

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 dist/
+dist-tests/
 node_modules/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+.idea/
+examples/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 The changelog is currently handwritten.
 
+# HEAD
+
+- Use `dist/index.js` instead of `src/index.js`.
+- Enhanced error messages.
+- Added test/examples.
+
 # 0.2.1 (2017-05-29)
 
 - Unknown identifiers now throw an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@ The changelog is currently handwritten.
 # HEAD
 
 - Use `dist/index.js` instead of `src/index.js`.
-- Enhanced error messages.
 - Added test/examples.
 
 # 0.2.1 (2017-05-29)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # Description
 
-`import-inject-loader` is a webpack loader allowing you to replace imported dependencies and global variables by custom implementations. At build time new exported functions are added to your module which makes it possible to change implementations at run time (e.g. within tests).
+`import-inject-loader` is a webpack loader which allows you to replace imported dependencies and global variables by custom implementations. At build time new exported functions are added to your module which makes it possible to change implementations at run time (e.g. within tests).
 
 # Usage
 
-Imagine we have a module like this:
+Imagine we have this module and want to mock `fetch` in our unit test:
 
 ```js
 export const getUsers = async () => {
@@ -15,44 +15,16 @@ export const getUsers = async () => {
 };
 ```
 
-The `getUsers` function is hard to test, because it requires a network request. With `import-inject-loader` we can mock `fetch` to get rid of the network request.
-
-To do so we simply import our module with the `import-inject-loader` and specify the names of imported or global variables we'd like to replace in a comma separated list:
+We can do it like this:
 
 ```js
+import expect from 'expect';
 import {
   getUsers,
   ilOverwriteFetch,
   ilResetAll
 } from 'import-inject-loader?fetch!../src/get-users';
-```
 
-You can see that two new functions are exported from `../src/get-users`: `ilOverwriteFetch` and `ilResetAll`.
-
-`ilOverwriteFetch` is exported, because we passed `?fetch` to the `import-inject-loader`. If we would pass `?fetch,Match,localStorage` the function `ilOverwriteFetch`, `ilOverwriteMath` and `ilOverwriteLocalStorage` would be exported (assuming all three variables are actually used in the file). If you pass `?fatch` - which is a typo - an error is thrown, because no `fatch` is used inside `../src/get-users`. The `ilOverwrite{Name}` functions allow you to swap out imported or global variables with own implementations.
-
-The `ilResetAll` is _always_ exported. It is a handy way to reset your custom implementations with the original implementation after your test is done.
-
-Note that you only change the implementation of `fetch` _within_ this one module. Other modules aren't affect and the global `fetch` on `window` isn't changed.
-
-The `import-inject-loader` _basically_ rewrites your module to something like this (not exactly, but you get the point):
-
-
-```js
-let fetch = window.fetch;
-
-export const ilOverwriteFetch = (newFetch) => fetch = newFetch;
-export const ilResetAll = () => fetch = window.fetch;
-
-export const getUsers = async () => {
-  const response = await fetch('https://jsonplaceholder.typicode.com/users');
-  return response.json();
-};
-```
-
-Within you test the usage looks like this:
-
-```js
 define('Test getUsers()', () => {
   it('should return users', async () => {
     // mock `fetch`
@@ -71,6 +43,42 @@ define('Test getUsers()', () => {
 
   afterEach(ilResetAll);
 });
+```
+
+# Explanation
+
+The `getUsers` function is hard to test, because it requires a network request. With `import-inject-loader` we can mock `fetch` to get rid of the network request.
+
+To do so we simply import our module with the `import-inject-loader` and specify the names of imported or global variables we'd like to replace in a comma separated list:
+
+```js
+import {
+  getUsers,
+  ilOverwriteFetch,
+  ilResetAll
+} from 'import-inject-loader?fetch!../src/get-users';
+```
+
+You can see that two new functions are exported from `../src/get-users`: `ilOverwriteFetch` and `ilResetAll`.
+
+`ilOverwriteFetch` is exported, because we passed `?fetch` to the `import-inject-loader`. If we would pass `?fetch,Math,localStorage` the function `ilOverwriteFetch`, `ilOverwriteMath` and `ilOverwriteLocalStorage` would be exported (assuming all three variables are actually used in the file). If you pass `?fatch` - which is a typo - an error is thrown, because no `fatch` is used inside `../src/get-users`. The `ilOverwrite{Name}` functions allow you to swap out imported or global variables with own implementations.
+
+The `ilResetAll` is _always_ exported. It is a handy way to reset your custom implementations with the original implementation after your test is done.
+
+Note that you only change the implementation of `fetch` _within_ this one module. Other modules aren't affect and the global `fetch` on `window` isn't changed.
+
+The `import-inject-loader` _basically_ rewrites your module to something like this (not exactly, but you get the point):
+
+```js
+let fetch = window.fetch;
+
+export const ilOverwriteFetch = (newFetch) => fetch = newFetch;
+export const ilResetAll = () => fetch = window.fetch;
+
+export const getUsers = async () => {
+  const response = await fetch('https://jsonplaceholder.typicode.com/users');
+  return response.json();
+};
 ```
 
 As explained this functionallity is not limited to global variables. You can also mock imported variables. Say you have another module which uses our `getUsers` like this:

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "examples-for-import-inject-loader",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "webpack --hide-modules && mocha dist-tests/unit.js"
+  },
+  "devDependencies": {
+    "expect": "^1.20.2",
+    "import-inject-loader": "file:../",
+    "mocha": "^3.4.2",
+    "webpack": "^2.6.1"
+  },
+  "dependencies": {
+    "rfnd-hello-world": "^1.0.0"
+  }
+}

--- a/examples/src/get-hello-world.js
+++ b/examples/src/get-hello-world.js
@@ -1,0 +1,3 @@
+import { HELLO_WORLD } from 'rfnd-hello-world';
+
+export const getHelloWorld = () => HELLO_WORLD;

--- a/examples/src/get-random.js
+++ b/examples/src/get-random.js
@@ -1,0 +1,1 @@
+export const getRandom = () => Math.random();

--- a/examples/tests/get-hello-world.js
+++ b/examples/tests/get-hello-world.js
@@ -1,0 +1,19 @@
+import expect from 'expect';
+import {
+  getHelloWorld,
+  ilOverwriteHELLO_WORLD,
+  ilResetAll
+} from 'import-inject-loader?HELLO_WORLD!../src/get-hello-world';
+
+describe('getHelloWorld()', () => {
+  it('should return "Hello world!"', () => {
+    expect(getHelloWorld()).toBe('Hello world!');
+  });
+
+  it('should return "Mocked world!"', () => {
+    ilOverwriteHELLO_WORLD('Mocked world!');
+    expect(getHelloWorld()).toBe('Mocked world!');
+  });
+
+  afterEach(ilResetAll);
+});

--- a/examples/tests/get-random.js
+++ b/examples/tests/get-random.js
@@ -1,0 +1,25 @@
+import expect from 'expect';
+import {
+  getRandom,
+  ilOverwriteMath,
+  ilResetAll
+} from 'import-inject-loader?Math!../src/get-random';
+
+describe('getRandom()', () => {
+  it('should return 2 instead of random number', () => {
+    const mockedMath = {
+      random() {
+        return 2;
+      }
+    };
+    ilOverwriteMath(mockedMath);
+
+    expect(getRandom()).toBe(2);
+  });
+
+  it('should never return 2', () => {
+    expect(getRandom()).toNotBe(2);
+  });
+
+  afterEach(ilResetAll);
+});

--- a/examples/tests/unit.js
+++ b/examples/tests/unit.js
@@ -1,0 +1,2 @@
+import './get-random';
+import './get-hello-world';

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  entry: './tests/unit.js',
+  output: {
+    filename: 'dist-tests/unit.js'
+  },
+  stats: 'errors-only'
+};

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "import-inject-loader",
   "version": "0.2.1",
-  "description": "This webpack loader replaces imports by own implementations and is especially suitable for testing and mocking dependencies.",
-  "main": "src/index.js",
+  "description": "This webpack loader allows you to overwrite dependencies by own implementations for testing purposes.",
+  "main": "dist/index.js",
   "scripts": {
-    "build": "ws b"
+    "build": "ws build",
+    "test": "npm run build && node tests"
   },
   "ws": {
     "type": "node",

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const loaderPrefix = 'il';
 module.exports = function (contentStr, sourceMap) {
   const options = loaderUtils.parseQuery(this.query);
   if (!options) {
-    throw new Error('No options specified! Use "import-inject-loader?fieldA,fieldB!../file"');
+    throw new Error('No options specified for import-inject-loader! If you want to use this loader you need to pass names of imported or globals variables you want to overwrite in this way: "import-inject-loader?fieldA,fieldB!../your-file".');
   }
 
   // parse AST
@@ -21,7 +21,7 @@ module.exports = function (contentStr, sourceMap) {
 
   // replace imports by custom import which can be overwritten
   const imports = Object.keys(options);
-  imports.forEach(key => replaceKeyByInject(key, ast));
+  imports.forEach(key => replaceKeyByInject(key, ast, this.resourcePath));
 
   // export method to reset all overwritten imports
   addResetFunction(ast, imports);
@@ -32,9 +32,9 @@ module.exports = function (contentStr, sourceMap) {
     + '\n// END-import-inject-loader';
 };
 
-function replaceKeyByInject(key, ast) {
+function replaceKeyByInject(key, ast, resourcePath) {
   if (!fileUsesIdentifier(ast, key)) {
-    throw new Error(`Identifier "${key}" is not used.`);
+    throw new Error(`It looks like you want to overwrite an imported or global variable called "${key}", but "${key}" can't be found inside "${resourcePath}".`);
   }
 
   const {

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const loaderPrefix = 'il';
 module.exports = function (contentStr, sourceMap) {
   const options = loaderUtils.parseQuery(this.query);
   if (!options) {
-    throw new Error('No options specified for import-inject-loader! If you want to use this loader you need to pass names of imported or globals variables you want to overwrite in this way: "import-inject-loader?fieldA,fieldB!../your-file".');
+    throw new Error('No options specified! Use "import-inject-loader?fieldA,fieldB!../file"');
   }
 
   // parse AST
@@ -21,7 +21,7 @@ module.exports = function (contentStr, sourceMap) {
 
   // replace imports by custom import which can be overwritten
   const imports = Object.keys(options);
-  imports.forEach(key => replaceKeyByInject(key, ast, this.resourcePath));
+  imports.forEach(key => replaceKeyByInject(key, ast));
 
   // export method to reset all overwritten imports
   addResetFunction(ast, imports);
@@ -32,9 +32,9 @@ module.exports = function (contentStr, sourceMap) {
     + '\n// END-import-inject-loader';
 };
 
-function replaceKeyByInject(key, ast, resourcePath) {
+function replaceKeyByInject(key, ast) {
   if (!fileUsesIdentifier(ast, key)) {
-    throw new Error(`It looks like you want to overwrite an imported or global variable called "${key}", but "${key}" can't be found inside "${resourcePath}".`);
+    throw new Error(`Identifier "${key}" is not used.`);
   }
 
   const {

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,9 @@
+const execSync = require('child_process').execSync;
+const join = require('path').join;
+
+const cwd = join(process.cwd(), 'examples');
+const stdio = 'inherit';
+
+execSync('npm install', { cwd, stdio });
+execSync('npm install import-inject-loader', { cwd, stdio });
+execSync('npm -s test', { cwd, stdio });


### PR DESCRIPTION
Hi @floric, 

I added an `examples/` directory which acts also as a small test for `import-inject-loader`. I updated the `README.md` with a slightly more complete example, too.

The last change I made was the `"main"` field in the `package.json`. Currently the `src/index.js` was used instead of the build file in `dist/index.js`. Also added a `.npmignore` so the `.gitignore` is not picked up by npm. 

In a future PR I'll add Travis support (- if you don't want to do it).

When this PR is merged, I'll collect some API feedback on Twitter 👍 

Thank you for reviewing.